### PR TITLE
Make profile::base cross-platform

### DIFF
--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -1,5 +1,0 @@
-class profile::base {
-
-  #the base profile should include component modules that will be on all nodes
-
-}

--- a/site/profile/manifests/base/linux.pp
+++ b/site/profile/manifests/base/linux.pp
@@ -1,0 +1,6 @@
+# A 'base' profile should include component modules that will be on all nodes
+# of a particular operating system.
+
+class profile::base::linux {
+
+}

--- a/site/profile/manifests/base/windows.pp
+++ b/site/profile/manifests/base/windows.pp
@@ -1,0 +1,6 @@
+# A 'base' profile should include component modules that will be on all nodes
+# of a particular operating system.
+
+class profile::base::windows {
+
+}

--- a/site/role/manifests/database_server.pp
+++ b/site/role/manifests/database_server.pp
@@ -2,6 +2,6 @@ class role::database_server {
 
   #This role would be made of all the profiles that need to be included to make a database server work
   #All roles should include the base profile
-  include profile::base
+  include profile::base::linux
 
 }

--- a/site/role/manifests/webserver.pp
+++ b/site/role/manifests/webserver.pp
@@ -2,6 +2,6 @@ class role::webserver {
 
   #This role would be made of all the profiles that need to be included to make a webserver work
   #All roles should include the base profile
-  include profile::base
+  include profile::base::linux
 
 }


### PR DESCRIPTION
This commit removes the profile::base definition from the site modules, and replaces it with two subclasses, profile::base::windows and profile::base::linux, to suggest that multiple operating systems' base profiles should be separate classes, rather than one big one with a large case statement.