### PR TITLE
Add os-specific sub-classes and have profile::base use case $::kernel

### DIFF
--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -1,5 +1,14 @@
+# Base profiles include all the classes that should be included on all nodes.
+# For cross-platform compatibility, this is broken up into platform-appropriate
+# subclasses.  This class applies the appropriate base profile based on the
+# $::kernel fact.
+
 class profile::base {
 
-  #the base profile should include component modules that will be on all nodes
+  # Include a platform-appropriate base profile
+  case $::kernel {
+    'Linux':   { include profile::base::linux   }
+    'windows': { include profile::base::windows }
+  }
 
 }

--- a/site/profile/manifests/base/linux.pp
+++ b/site/profile/manifests/base/linux.pp
@@ -1,0 +1,6 @@
+# A 'base' profile should include component modules that will be on all nodes
+# of a particular operating system.
+
+class profile::base::linux {
+
+}

--- a/site/profile/manifests/base/windows.pp
+++ b/site/profile/manifests/base/windows.pp
@@ -1,0 +1,6 @@
+# A 'base' profile should include component modules that will be on all nodes
+# of a particular operating system.
+
+class profile::base::windows {
+
+}


### PR DESCRIPTION
This commit turns profile::base into a case statement based on $::kernel that includes an os-appropriate sub sub-class.  It also adds empty profiles for base::windows and base::linux.