### PR TITLE
Add Auto Vacuum Settings to PostgreSQL

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,3 +38,7 @@ mod 'gms',
 mod 'pltraining-rbac',
   :git    => 'https://github.com/puppetlabs/pltraining-rbac',
   :ref    => '2f60e1789a721ce83f8df061e13f8bf81cd4e4ce'
+
+mod 'pe_databases',
+  :git => 'https://github.com/npwalker/pe_databases',
+  :ref => 'ce51abffa029d910f84b44160791e7406f2da864'

--- a/site/profile/manifests/pe_postgresql_management.pp
+++ b/site/profile/manifests/pe_postgresql_management.pp
@@ -1,6 +1,7 @@
 class profile::pe_postgresql_management (
   $autovacuum_scale_factor   = '.01',
   $manage_postgresql_service = true,
+  $all_in_one_pe_install     = true,
 ) {
 
   $postgresql_service_resource_name = 'postgresqld'
@@ -9,12 +10,17 @@ class profile::pe_postgresql_management (
     true    => Service[$postgresql_service_resource_name],
     default => undef,
   }
+  $notify_console_services = $all_in_one_pe_install ? {
+    true    => Service['pe-console-services'],
+    default => undef,
+  }
 
   if $manage_postgresql_service {
     service { $postgresql_service_resource_name :
       name   => $postgresql_service_name,
       ensure => running,
       enable => true,
+      notify => $notify_console_services
     }
   }
 

--- a/site/profile/manifests/pe_postgresql_management.pp
+++ b/site/profile/manifests/pe_postgresql_management.pp
@@ -1,8 +1,8 @@
 class profile::pe_postgresql_management (
-  $autovacuum_scale_factor                  = '.01',
-  $manage_postgresql_service                = true,
-  $all_in_one_pe_install                    = true,
-  Boolean $include_pe_databases_maintenance = true,
+  Float[0,1] $autovacuum_scale_factor          = 0.01,
+  Boolean    $manage_postgresql_service        = true,
+  Boolean    $all_in_one_pe_install            = true,
+  Boolean    $include_pe_databases_maintenance = true,
 ) {
 
   $postgresql_service_resource_name = 'postgresqld'
@@ -25,11 +25,13 @@ class profile::pe_postgresql_management (
     }
   }
 
+  #The value attribute of postgresql_conf requires a string despite validating a float above
+  #https://tickets.puppetlabs.com/browse/MODULES-2960
   #http://www.postgresql.org/docs/9.4/static/runtime-config-autovacuum.html
   postgresql_conf { ['autovacuum_vacuum_scale_factor', 'autovacuum_analyze_scale_factor'] :
     ensure => present,
     target => '/opt/puppetlabs/server/data/postgresql/9.4/data/postgresql.conf',
-    value  => $autovacuum_scale_factor,
+    value  => "${autovacuum_scale_factor}",
     notify => $notify_postgresql_service,
   }
 

--- a/site/profile/manifests/pe_postgresql_management.pp
+++ b/site/profile/manifests/pe_postgresql_management.pp
@@ -1,0 +1,29 @@
+class profile::pe_postgresql_management (
+  $autovacuum_scale_factor   = '.01',
+  $manage_postgresql_service = true,
+) {
+
+  $postgresql_service_resource_name = 'postgresqld'
+  $postgresql_service_name          = 'pe-postgresql'
+  $notify_postgresql_service        = $manage_postgresql_service ? {
+    true    => Service[$postgresql_service_resource_name],
+    default => undef,
+  }
+
+  if $manage_postgresql_service {
+    service { $postgresql_service_resource_name :
+      name   => $postgresql_service_name,
+      ensure => running,
+      enable => true,
+    }
+  }
+
+  #http://www.postgresql.org/docs/9.4/static/runtime-config-autovacuum.html
+  postgresql_conf { ['autovacuum_vacuum_scale_factor', 'autovacuum_analyze_scale_factor'] :
+    ensure => present,
+    target => '/opt/puppetlabs/server/data/postgresql/9.4/data/postgresql.conf',
+    value  => $autovacuum_scale_factor,
+    notify => $notify_postgresql_service,
+  }
+
+}

--- a/site/profile/manifests/pe_postgresql_management.pp
+++ b/site/profile/manifests/pe_postgresql_management.pp
@@ -1,7 +1,8 @@
 class profile::pe_postgresql_management (
-  $autovacuum_scale_factor   = '.01',
-  $manage_postgresql_service = true,
-  $all_in_one_pe_install     = true,
+  $autovacuum_scale_factor                  = '.01',
+  $manage_postgresql_service                = true,
+  $all_in_one_pe_install                    = true,
+  Boolean $include_pe_databases_maintenance = true,
 ) {
 
   $postgresql_service_resource_name = 'postgresqld'
@@ -30,6 +31,11 @@ class profile::pe_postgresql_management (
     target => '/opt/puppetlabs/server/data/postgresql/9.4/data/postgresql.conf',
     value  => $autovacuum_scale_factor,
     notify => $notify_postgresql_service,
+  }
+
+  #https://github.com/npwalker/pe_databases
+  if $include_pe_databases_maintenance {
+    include pe_databases::maintenance
   }
 
 }

--- a/site/role/manifests/all_in_one_pe.pp
+++ b/site/role/manifests/all_in_one_pe.pp
@@ -2,5 +2,6 @@ class role::all_in_one_pe {
 
   include profile::puppetmaster
   include profile::git_webhook
+  include profile::pe_postgresql_management
 
 }


### PR DESCRIPTION
In the past I've seen the console and puppetdb databases grow
much larger than expected and I have a hypothesis that this is
because the default 20% setting for autovacuum is too high for our
workload.  So, there's a potential that changing this to 1%
might be too low and might reduce performance but it should
reduce disk usage and it can always be tuned upward if the
performance hit is too large, however, it is much more difficult
to reduce the size of a database after it has grown too large.

Basically, I'm erring on the side of using less disk space and
hopefully less outages due to running out of disk space and we
can open a conversation on performance later if one needs to be had.