### PR TITLE
Fix hostname on role creation curl command

### DIFF
--- a/site/profile/manifests/git_webhook/code_manager.pp
+++ b/site/profile/manifests/git_webhook/code_manager.pp
@@ -39,7 +39,7 @@ class profile::git_webhook::code_manager {
   $create_role_creates_file = '/etc/puppetlabs/puppetserver/.puppetlabs/deploy_environments_created'
   $create_role_curl = @(EOT)
     /opt/puppetlabs/puppet/bin/curl -k -X POST -H 'Content-Type: application/json' \
-    https://<%= $::trusted['certname'] %>:4433/rbac-api/v1/roles \
+    https://<%= $classifier_hostname %>:4433/rbac-api/v1/roles \
     -d '{"permissions": [{"object_type": "environment", "action": "deploy_code", "instance": "*"},
     {"object_type": "tokens", "action": "override_lifetime", "instance": "*"}],"user_ids": [], "group_ids": [], "display_name": "<%= $code_manager_role_name  %>", "description": ""}' \
     --cert <%= $::settings::certdir %>/<%= $::trusted['certname'] %>.pem  \


### PR DESCRIPTION
Prior to the this commit, if you were using the code_manager
profile on a split install it would incorrectly try to curl the
NC api on the master node.

After this commit, it should correctly curl the hostname of the NC

This has no impact on the functionality of the code on a monolithic
PE installation.