### PR TITLE
Update all_in_one_pe_2015_2.pp

### DIFF
--- a/site/role/manifests/all_in_one_pe_2015_2.pp
+++ b/site/role/manifests/all_in_one_pe_2015_2.pp
@@ -1,6 +1,6 @@
 class role::all_in_one_pe_2015_2 {
 
    include profile::puppetmaster
-   include profile::zack_r10k_webhook
+   include profile::git_webhook
 
 }


### PR DESCRIPTION
Shouldn't this be profile::git_webhook as in all_in_one_pe.pp since the abstraction logic is located there?
Either that or the profile::zack_r10k_webook is missing from the location specified?