### PR TITLE
Disable max-requests-per-instance to mitigate hiera-eyaml mem leak

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,7 +2,7 @@
 message: "This node is using common data"
 
 #Puppet Server Tuning
-puppet_enterprise::master::puppetserver::jruby_max_requests_per_instance: 10000
+puppet_enterprise::master::puppetserver::jruby_max_requests_per_instance: 0
 #Enable code manager
 puppet_enterprise::profile::master::code_manager_auto_configure: true
 puppet_enterprise::master::code_manager::authenticate_webhook: false


### PR DESCRIPTION
Hiera-eyaml currently causes a memory leak in puppetsever when
max-requests-per-instnace is enabled. So, defaulting to disabling
max-requests-per-instance.

https://tickets.puppetlabs.com/browse/SERVER-1154
https://github.com/TomPoulton/hiera-eyaml/issues/163