### PR TITLE
restore 10000 for jruby max-requests-per-instance

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -2,4 +2,4 @@
 message: "This node is using common data"
 
 #Puppet Server Tuning
-puppet_enterprise::master::puppetserver::jruby_max_requests_per_instance: 0
+puppet_enterprise::master::puppetserver::jruby_max_requests_per_instance: 10000


### PR DESCRIPTION
Given https://tickets.puppetlabs.com/browse/SERVER-1154 is now resolved, we can restore the 10,000 value for jruby max-requests-per-instance. This is the default that is installed in 2016.2, too. 
