### PR TITLE
Add ruby shebang to config_version scripts

### DIFF
--- a/scripts/code_manager_config_version.rb
+++ b/scripts/code_manager_config_version.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require 'json'
 
 environmentpath = ARGV[0]

--- a/scripts/config_version.rb
+++ b/scripts/config_version.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 begin
   require 'rugged'
 rescue LoadError => e


### PR DESCRIPTION
Prior to this commit, if you used windows bash git when you clone
down the repo these files would get incorrect permissions which
make them unexecutable.

After this commit, due to some windows bash git magic I don't
understand it appears that adding the shebang to the beginning of
the file causes windows bash git to change the permissions to
so the file is executable.

This resolves https://github.com/puppetlabs/control-repo/issues/40