### PR TITLE
config_version: Show the compiling master's name

### DIFF
--- a/scripts/code_manager_config_version.rb
+++ b/scripts/code_manager_config_version.rb
@@ -1,10 +1,18 @@
-#!/usr/bin/env ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 require 'json'
+require 'socket'
 
 environmentpath = ARGV[0]
 environment     = ARGV[1]
 
+# Get the hostname of the Puppet master compiling the catalog.
+compiling_master = Socket.gethostname
+
+# Get the path to the Code Manager deployment info file.
 r10k_deploy_file_path = File.join(environmentpath, environment, '.r10k-deploy.json')
 
-#output the sha1 from the control-repo
-puts JSON.parse(File.read(r10k_deploy_file_path))['signature']
+# Get the first 12 characters of the commit ID out of the deployment file.
+commit_id = JSON.parse(File.read(r10k_deploy_file_path))['signature'][0...11]
+
+# Show the compiling master, environment name, and commit ID.
+puts "#{compiling_master}-#{environment}-#{commit_id}"

--- a/scripts/config_version.rb
+++ b/scripts/config_version.rb
@@ -1,24 +1,24 @@
 #!/usr/bin/env ruby
 begin
   require 'rugged'
+  require 'socket'
 rescue LoadError => e
   t = Time.new
   puts t.to_i
 else
-
   environmentpath = ARGV[0]
   environment     = ARGV[1]
 
+  # Get the hostname of the Puppet master compiling the catalog.
+  compiling_master = Socket.gethostname
+
+  # Get the path to the environment being compiled.
   repo = Rugged::Repository.discover(File.join(environmentpath, environment))
-  head  = repo.head
+  head = repo.head
 
-  #sha1 hash of the newest commit
-  head_sha = head.target_id
+  # First 12 characters of the sha1 hash of the newest commit.
+  commit_id = head.target_id[0...11]
 
-  #the commit message associated the newest commit
-  commit = repo.lookup(head_sha)
-
-  #add something to find the remote url
-
-  puts head_sha 
+  # Show the compiling master, environment name, and commit ID.
+  puts "#{compiling_master}-#{environment}-#{commit_id}"
 end

--- a/scripts/config_version.sh
+++ b/scripts/config_version.sh
@@ -3,10 +3,10 @@ if [ -e $1/$2/.r10k-deploy.json ]
 then
   /opt/puppetlabs/puppet/bin/ruby $1/$2/scripts/code_manager_config_version.rb $1 $2
 elif [ -e /opt/puppetlabs/server/pe_version ]
-then 
-  /opt/puppetlabs/puppet/bin/ruby $1/$2/scripts/config_version.rb $1 $2  
+then
+  /opt/puppetlabs/puppet/bin/ruby $1/$2/scripts/config_version.rb $1 $2
 else
   /usr/bin/git --version > /dev/null 2>&1 &&
   /usr/bin/git --git-dir $1/$2/.git rev-parse HEAD ||
   date +%s
-fi 
+fi


### PR DESCRIPTION
Prior to this, the config_version script just showed the commit ID of
the version of code being compiled. This commit includes the compiling
Puppet master's hostname and environment name in the config_version.
This is very useful for debugging when a Puppet master is failing and
you have multiple masters behind a load balancer.

The output of config_version now looks like this:

`info: Applying configuration version 'pupmaster01-production-ac9785273a10'`