### PR TITLE
Ignore modules pulled from r10k

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-hieradata/nodes/example-puppet-master.yaml
+modules/


### PR DESCRIPTION
Prior to this, modules that were deployed with r10k into the ./modules
directory weren't being ignored by git.

When doing local development or testing, it's nice to be able to run
`r10k puppetfile install` to pull down modules from the Puppetfile.
After this commit, those modules won't be tracked by git.