### PR TITLE
Config Version Improvements

### DIFF
--- a/scripts/code_manager_config_version.rb
+++ b/scripts/code_manager_config_version.rb
@@ -6,7 +6,8 @@ environmentpath = ARGV[0]
 environment     = ARGV[1]
 
 # Get the hostname of the Puppet master compiling the catalog.
-compiling_master = Socket.gethostname
+# Sometimes the hostname is the fqdn, so we'll take the first segment.
+compiling_master = Socket.gethostname.split('.').first
 
 # Get the path to the Code Manager deployment info file.
 r10k_deploy_file_path = File.join(environmentpath, environment, '.r10k-deploy.json')

--- a/scripts/config_version.rb
+++ b/scripts/config_version.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 begin
   require 'rugged'
   require 'socket'

--- a/scripts/config_version.rb
+++ b/scripts/config_version.rb
@@ -10,7 +10,8 @@ else
   environment     = ARGV[1]
 
   # Get the hostname of the Puppet master compiling the catalog.
-  compiling_master = Socket.gethostname
+  # Sometimes the hostname is the fqdn, so we'll take the first segment.
+  compiling_master = Socket.gethostname.split('.').first
 
   # Get the path to the environment being compiled.
   repo = Rugged::Repository.discover(File.join(environmentpath, environment))


### PR DESCRIPTION
This PR makes two changes to the config_version scripts:

1. Use the puppet-agent ruby stack, not system.
1. Show the short hostname, not the FQDN.