### PR TITLE
Handle colon-delimited environmentpath in config_version.sh

### DIFF
--- a/scripts/config_version.sh
+++ b/scripts/config_version.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 
+ENVIRONMENTPATH=$1
+# $ENVIRONMENTPATH may contain multiple colon-delimited locations.
+# We need to pick the first one that contains $ENVIRONMENT.
+IFS=":"
+for CANDIDATEPATH in ${ENVIRONMENTPATH}; do
+  if [ -d "${CANDIDATEPATH}/${2}" ]; then
+    ENVIRONMENTPATH=$CANDIDATEPATH
+    break
+  fi
+done
+
 # Usage
-if [ $# -ne 2 -o ! -d "$1" -o ! -d "$1/$2" ]; then
+if [ $# -ne 2 -o ! -d "${ENVIRONMENTPATH}" -o ! -d "${ENVIRONMENTPATH}/$2" ]; then
   echo "usage: $0 <environmentpath> <environment>" >&2
   exit 1
 fi
@@ -14,19 +25,19 @@ ruby() {
 }
 
 # Determine how best to calculate a config_version
-if [ -e $1/$2/.r10k-deploy.json ]; then
+if [ -e ${ENVIRONMENTPATH}/$2/.r10k-deploy.json ]; then
   # The environment was deployed using r10k. We will calculate the config
   # version using the r10k data.
-  ruby $1/$2/scripts/config_version-r10k.rb $1 $2
+  ruby ${ENVIRONMENTPATH}/$2/scripts/config_version-r10k.rb $1 $2
 
 elif [ -e /opt/puppetlabs/server/pe_version ]; then
   # This is a Puppet Enterprise system and we can rely on the rugged ruby gem
   # being available.
-  ruby $1/$2/scripts/config_version-rugged.rb $1 $2
+  ruby ${ENVIRONMENTPATH}/$2/scripts/config_version-rugged.rb $1 $2
 
 elif type git >/dev/null; then
   # The git command is available.
-  git --git-dir $1/$2/.git rev-parse HEAD
+  git --git-dir ${ENVIRONMENTPATH}/$2/.git rev-parse HEAD
 
 else
   # Nothing else available; just use the date.


### PR DESCRIPTION
`environment.conf` passes the Puppet configuration value `$environmentpath` as an argument to `config_version.sh`. This value [supports a colon-separated list](https://puppet.com/docs/puppet/5.4/config_file_main.html#paths) of paths, but when one is used the config_version scripts currently bomb out.

This fixes them to handle colon-delimited `environmentpath`.