### PR TITLE
Update outdated info and links in site.pp comments

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,30 +1,29 @@
 ## site.pp ##
 
-# This file (/etc/puppetlabs/puppet/manifests/site.pp) is the main entry point
+# This file (./manifests/site.pp) is the main entry point
 # used when an agent connects to a master and asks for an updated configuration.
+# https://puppet.com/docs/puppet/latest/dirs_manifest.html
 #
 # Global objects like filebuckets and resource defaults should go in this file,
-# as should the default node definition. (The default node can be omitted
-# if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
-# node definitions.)
+# as should the default node definition if you want to use it.
 
 ## Active Configurations ##
 
 # Disable filebucket by default for all File resources:
-#https://docs.puppet.com/pe/2015.3/release_notes.html#filebucket-resource-no-longer-created-by-default
+# https://github.com/puppetlabs/docs-archive/blob/master/pe/2015.3/release_notes.markdown#filebucket-resource-no-longer-created-by-default
 File { backup => false }
 
-# DEFAULT NODE
-# Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
-# node definitions.
+## Node Definitions ##
 
 # The default node definition matches any node lacking a more specific node
-# definition. If there are no other nodes in this file, classes declared here
-# will be included in every node's catalog, *in addition* to any classes
-# specified in the console for that node.
-
+# definition. If there are no other node definitions in this file, classes
+# and resources declared in the default node definition will be included in
+# every node's catalog.
+#
+# Note that node definitions in this file are merged with node data from the
+# Puppet Enterprise console and External Node Classifiers (ENC's).
+#
+# For more on node definitions, see: https://puppet.com/docs/puppet/latest/lang_node_definitions.html
 node default {
   # This is where you can declare classes for all nodes.
   # Example:


### PR DESCRIPTION
This commit attempts to cleanup and modernize the comments in site.pp a bit.

For one thing, I've updated the docs links to point to working URL's.
For another, I tried to reorganize, clarify, and deduplicate the comments.