### PR TITLE
update the version of the example modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,9 +2,9 @@ forge 'https://forge.puppet.com'
 
 # Modules from the Puppet Forge
 # Versions should be updated to be the latest at the time you start
-#mod 'puppetlabs/inifile', '3.0.0'
-#mod 'puppetlabs/stdlib',  '6.0.0'
-#mod 'puppetlabs/concat',  '6.0.0'
+#mod 'puppetlabs/inifile', '5.0.1'
+#mod 'puppetlabs/stdlib',  '7.0.1'
+#mod 'puppetlabs/concat',  '7.0.1'
 
 # Modules from Git
 # Examples: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#examples


### PR DESCRIPTION
### Changes

I'm updating the version of the example modules on the Puppetfile to the latest ones.

We have the message on line No. 5:

> Versions should be updated to be the latest at the time you start

But as a Puppet user, It's always nice to have the closest versions already there in the template you just cloned.

Let me know what you all think :)

Thanks,