### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## What You Get From This control-repo
 
-This is a template [control repository](https://puppet.com/docs/pe/latest/code_management/control_repo.html) that has the minimum amount of scaffolding to make it easy to get started with [r10k](https://puppet.com/docs/pe/latest/code_management/r10k.html) or Puppet Enterprise's [Code Manager](https://puppet.com/docs/pe/latest/code_management/code_mgr.html).
+This is a template [control repository](https://puppet.com/docs/pe/latest/control_repo.html) that has the minimum amount of scaffolding to make it easy to get started with [r10k](https://puppet.com/docs/pe/latest/r10k.html) or Puppet Enterprise's [Code Manager](https://puppet.com/docs/pe/latest/code_mgr.html).
 
 The important files and items in this template are as follows:
 
@@ -18,10 +18,10 @@ The important files and items in this template are as follows:
 * An example Puppetfile with various module references.
 * An example Hiera configuration file and data directory with pre-created common.yaml and nodes directory.
   * These match the default hierarchy that ships with PE.
-* An [environment.conf](https://puppet.com/docs/puppet/5.3/config_file_environment.html) that correctly implements:
+* An [environment.conf](https://puppet.com/docs/puppet/7/config_file_environment.html) that correctly implements:
   * A site-modules directory for roles, profiles, and any custom modules for your organization.
   * A config\_version script.
-* An example [config\_version](https://puppet.com/docs/puppet/5.3/config_file_environment.html#configversion) script that outputs the git commit ID of the code that was used during a Puppet run.
+* An example [config\_version](https://puppet.com/docs/puppet/7/config_file_environment.html#environment-conf-allowed-settings) script that outputs the git commit ID of the code that was used during a Puppet run.
 
 Here's a visual representation of the structure of this repository:
 
@@ -57,10 +57,10 @@ To get started with using the control-repo template in your own environment and 
 1. After GitLab is installed you may sign in with the `root` user and password `5iveL!fe`.
 1. Make a user for yourself.
 1. Make an SSH key to link with your user. You’ll want to do this on the machine you intend to edit code from (most likely not your Puppet master, but your local workstation or laptop).
-    * <http://doc.gitlab.com/ce/ssh/README.html>
+    * <https://docs.gitlab.com/ee/ssh/index.html>
     * <https://help.github.com/articles/generating-ssh-keys/>
 1. Create a group called `puppet` (this is case sensitive).
-    * <http://doc.gitlab.com/ce/workflow/groups.html>
+    * <https://docs.gitlab.com/ee/user/group/index.html>
 1. Add your user to the `puppet` group as well.
 1. Create a project called `control-repo`, and set the Namespace to be the `puppet` group.
 1. Clone this control repository to your laptop/workstation:


### PR DESCRIPTION
All links to Puppet's Code Manager were broken. The Puppet 5 links are updated to version 7. The Gitlab links redirect somewhere else. The direct link saves users a redirect.