### PR TITLE
check if git repo exists when generating config version

### DIFF
--- a/scripts/config_version.sh
+++ b/scripts/config_version.sh
@@ -24,7 +24,7 @@ elif [ -e /opt/puppetlabs/server/pe_version ]; then
   # being available.
   ruby $1/$2/scripts/config_version-rugged.rb $1 $2
 
-elif type git >/dev/null; then
+elif type git >/dev/null && [ -d "$1/$2/.git" ]; then
   # The git command is available.
   git --git-dir $1/$2/.git rev-parse HEAD
 


### PR DESCRIPTION
If git is installed on the system but the control repo is actually not a git repo the scripts/config_version.sh script fails.
Fixed by checking if `.git` exists.

See https://github.com/puppetlabs/control-repo/issues/86