### PR TITLE
Moved the roles and profile comments to the top

### DIFF
--- a/site-modules/profile/manifests/base.pp
+++ b/site-modules/profile/manifests/base.pp
@@ -1,5 +1,4 @@
+# The base profile should include component modules that will be on all nodes
 class profile::base {
-
-  #the base profile should include component modules that will be on all nodes
 
 }

--- a/site-modules/profile/manifests/example.pp
+++ b/site-modules/profile/manifests/example.pp
@@ -1,3 +1,4 @@
+# An example profile
 class profile::example {
 
 }

--- a/site-modules/role/manifests/database_server.pp
+++ b/site-modules/role/manifests/database_server.pp
@@ -1,7 +1,7 @@
+# This role would be made of all the profiles that need to be included to make a database server work
+# All roles should include the base profile
 class role::database_server {
 
-  #This role would be made of all the profiles that need to be included to make a database server work
-  #All roles should include the base profile
   include profile::base
 
 }

--- a/site-modules/role/manifests/example.pp
+++ b/site-modules/role/manifests/example.pp
@@ -1,3 +1,4 @@
+# An example role
 class role::example {
 
 }

--- a/site-modules/role/manifests/webserver.pp
+++ b/site-modules/role/manifests/webserver.pp
@@ -1,7 +1,7 @@
+# This role would be made of all the profiles that need to be included to make a webserver work
+# All roles should include the base profile
 class role::webserver {
 
-  #This role would be made of all the profiles that need to be included to make a webserver work
-  #All roles should include the base profile
   include profile::base
 
 }


### PR DESCRIPTION
The new training courses (and the old Practitioner) are telling students to run a pdk convert in the roles module and the profiles module and then test new role and profile classes using pdk validate, this results in warnings;
```
pdk (WARNING): puppet-lint: class not documented (manifests/database_server.pp:1:1)
pdk (WARNING): puppet-lint: class not documented (manifests/webserver.pp:1:1)
pdk (WARNING): puppet-lint: class not documented (manifests/example.pp:1:1)
```
and
```
pdk (WARNING): puppet-lint: class not documented (manifests/example.pp:1:1)
pdk (WARNING): puppet-lint: class not documented (manifests/base.pp:1:1)
```
This seems reasonable, the roles and profiles modules are just modules and should follow the same rules. I'm expecting students will probably take this process back to their own environments. I've moved the comments (where they exist or added new ones) to the top of the class files to clear the WARNING messages and make things a bit tidier. We shouldn't be delivering a template that generates PDK warnings.