### PR TITLE
Add Static Plan Hierarchy

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,3 +10,7 @@ hierarchy:
     paths:
       - "nodes/%{trusted.certname}.yaml"
       - "common.yaml"
+plan_hierarchy:
+  - name: "Static data"
+    data_hash: yaml_data
+    path: "static.yaml"


### PR DESCRIPTION
Prior to this commit the plan_hierarchy would have to be added to the environment hiera.yaml in order to to hiera lookups from apply blocks in plans.

This change has no impact but to prevent having to add it later