### PR TITLE
feat: Add bolt project example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The important files and items in this template are as follows:
   * A site-modules directory for roles, profiles, and any custom modules for your organization.
   * A config\_version script.
 * An example [config\_version](https://puppet.com/docs/puppet/7/config_file_environment.html#environment-conf-allowed-settings) script that outputs the git commit ID of the code that was used during a Puppet run.
-* An example [bolt project](https://help.puppet.com/bolt/current/topics/projects.htm).
+* An example [Bolt project](https://help.puppet.com/bolt/current/topics/projects.htm).
 
 Here's a visual representation of the structure of this repository:
 
@@ -31,7 +31,7 @@ control-repo/
 │   ├── plans/                            # Bolt project only plans directory.
 │   ├── tasks/                            # Bolt project only tasks directory.
 │   ├── bolt-project.yaml                 # Bolt project configuration file supports options that configure how Bolt behaves.
-│   └── inventory.yaml                    # Bolt inventory file stores information about your targets and control how Bolt connects to them.
+│   └── inventory.yaml                    # Bolt inventory file stores information about your targets and controls how Bolt connects to them.
 ├── data/                                 # Hiera data directory.
 │   ├── nodes/                            # Node-specific data goes here.
 │   └── common.yaml                       # Common data goes here.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   * [Github](#github)
 * [Code Manager Setup](#code-manager-setup)
 
-
 ## What You Get From This control-repo
 
 This is a template [control repository](https://puppet.com/docs/pe/latest/control_repo.html) that has the minimum amount of scaffolding to make it easy to get started with [r10k](https://puppet.com/docs/pe/latest/r10k.html) or Puppet Enterprise's [Code Manager](https://puppet.com/docs/pe/latest/code_mgr.html).
@@ -22,11 +21,17 @@ The important files and items in this template are as follows:
   * A site-modules directory for roles, profiles, and any custom modules for your organization.
   * A config\_version script.
 * An example [config\_version](https://puppet.com/docs/puppet/7/config_file_environment.html#environment-conf-allowed-settings) script that outputs the git commit ID of the code that was used during a Puppet run.
+* An example [bolt project](https://help.puppet.com/bolt/current/topics/projects.htm).
 
 Here's a visual representation of the structure of this repository:
 
-```
+```text
 control-repo/
+├── bolt/                                 # Bolt project directory.
+│   ├── plans/                            # Bolt project only plans directory.
+│   ├── tasks/                            # Bolt project only tasks directory.
+│   ├── bolt-project.yaml                 # Bolt project configuration file supports options that configure how Bolt behaves.
+│   └── inventory.yaml                    # Bolt inventory file stores information about your targets and control how Bolt connects to them.
 ├── data/                                 # Hiera data directory.
 │   ├── nodes/                            # Node-specific data goes here.
 │   └── common.yaml                       # Common data goes here.
@@ -37,6 +42,7 @@ control-repo/
 │   ├── config_version.rb                 # A config_version script for r10k.
 │   └── config_version.sh                 # A wrapper that chooses the appropriate config_version script.
 ├── site-modules/                         # This directory contains site-specific modules and is added to $modulepath.
+│   ├── adhoc/                            # A module for ad-hoc tasks and plans that don't fit into a specific role/profile.
 │   ├── profile/                          # The profile module.
 │   └── role/                             # The role module.
 ├── LICENSE

--- a/bolt/.gitignore
+++ b/bolt/.gitignore
@@ -1,0 +1,7 @@
+.modules/
+.resource_types/
+bolt-debug.log
+.plan_cache.json
+.plugin_cache.json
+.task_cache.json
+.rerun.json

--- a/bolt/bolt-project.yaml
+++ b/bolt/bolt-project.yaml
@@ -1,0 +1,20 @@
+---
+name: control_repo_bolt
+
+# A list of module dependencies for the bolt project.
+#
+# @see https://help.puppet.com/bolt/current/topics/bolt_project_reference.htm#modules
+modules: []
+
+# Exposes the control repo's site-modules and modules directories to Bolt.
+# This allows you to run Bolt plans that use modules in the control repo without needing to install them separately in the Bolt project.
+#
+# @see https://help.puppet.com/bolt/current/topics/bolt_project_reference.htm#modulepath
+modulepath:
+  - ../site-modules
+  - ../modules
+
+# Path to the Hiera configuration file.
+#
+# @see https://help.puppet.com/bolt/current/topics/bolt_project_reference.htm#hiera-config
+hiera-config: ../hiera.yaml

--- a/bolt/bolt-project.yaml
+++ b/bolt/bolt-project.yaml
@@ -11,6 +11,8 @@ modules: []
 #
 # @see https://help.puppet.com/bolt/current/topics/bolt_project_reference.htm#modulepath
 modulepath:
+  - site-modules
+  - modules
   - ../site-modules
   - ../modules
 

--- a/bolt/inventory.yaml
+++ b/bolt/inventory.yaml
@@ -1,0 +1,27 @@
+# This is an example inventory.yaml
+# To read more about inventory files, see https://pup.pt/bolt-inventory
+#
+# groups:
+#   - name: linux
+#     targets:
+#       - target1.example.com
+#       - target2.example.com
+#     config:
+#       transport: ssh
+#       ssh:
+#         private-key: /path/to/private_key.pem
+#   - name: windows
+#     targets:
+#       - name: win1
+#         uri: target3.example.com
+#       - name: win2
+#         uri: target4.example.com
+#     config:
+#       transport: winrm
+# config:
+#   ssh:
+#     host-key-check: false
+#   winrm:
+#     user: Administrator
+#     password: Bolt!
+#     ssl: false

--- a/bolt/plans/bolt_only_plan.pp
+++ b/bolt/plans/bolt_only_plan.pp
@@ -1,10 +1,12 @@
 # This is a description for the bolt_only_plan.
 #
 # @param targets The targets to run the command on.
-# @param message The message to echo on the targets.
+# @param message The message to print on the targets.
 plan control_repo_bolt::bolt_only_plan(
   TargetSpec $targets,
   String $message,
 ) {
-  run_command("echo ${message}", $targets)
+  $escaped_message = "'${regsubst($message, /'/, "'\"'\"'", 'G')}'"
+
+  run_command("printf '%s\\n' ${escaped_message}", $targets)
 }

--- a/bolt/plans/bolt_only_plan.pp
+++ b/bolt/plans/bolt_only_plan.pp
@@ -1,0 +1,10 @@
+# This is a description for the bolt_only_plan.
+#
+# @param targets The targets to run the command on.
+# @param message The message to echo on the targets.
+plan control_repo_bolt::bolt_only_plan(
+  TargetSpec $targets,
+  String $message,
+) {
+  run_command("echo ${message}", $targets)
+}

--- a/bolt/tasks/bolt_only_task.json
+++ b/bolt/tasks/bolt_only_task.json
@@ -1,4 +1,3 @@
-
 {
     "description": "This is the description for the bolt_only_task task",
     "input_method": "environment"

--- a/bolt/tasks/bolt_only_task.json
+++ b/bolt/tasks/bolt_only_task.json
@@ -1,0 +1,5 @@
+
+{
+    "description": "This is the description for the bolt_only_task task",
+    "input_method": "environment"
+}

--- a/bolt/tasks/bolt_only_task.sh
+++ b/bolt/tasks/bolt_only_task.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello from a Bolt-only task!"


### PR DESCRIPTION
This pull request adds a Bolt project to the repository, providing a dedicated structure for Bolt-specific plans, tasks, and configuration. The changes include documentation updates to describe the new Bolt project, the addition of example Bolt configuration files, and the creation of example Bolt-only plans and tasks. These updates make it easier to use Bolt alongside the existing control-repo structure.

**Bolt Project Integration:**

* Added a new `bolt/` directory containing a Bolt project, including `bolt-project.yaml` for configuration, `inventory.yaml` as an example inventory, and `.gitignore` for Bolt-specific files.
* Created example Bolt-only plan `bolt/plans/bolt_only_plan.pp` and task files (`bolt/tasks/bolt_only_task.json`, `bolt/tasks/bolt_only_task.sh`) to demonstrate Bolt-specific functionality.

**Documentation and Structure Updates:**

* Updated `README.md` to document the new Bolt project, including a description, a link to Bolt project documentation, and an updated repository structure diagram highlighting the new `bolt/` directory and its contents.
* Added a note in the structure about the `adhoc/` module for ad-hoc tasks and plans.

## Resolves

#104
