### PR TITLE
feat: add type and provider example

### DIFF
--- a/site-modules/profile/.sync.yml
+++ b/site-modules/profile/.sync.yml
@@ -20,3 +20,9 @@ data/common.yaml:
   delete: true
 .fixtures:
   unmanaged: true
+
+# @see https://help.puppet.com/core/current/Content/PuppetCore/create_types_and_providers_resource_api.htm
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'puppet-resource_api'

--- a/site-modules/profile/Gemfile
+++ b/site-modules/profile/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem "rubocop-capybara", '~> 2.22.0',           require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:windows]
   gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:windows]
+  gem "puppet-resource_api",                     require: false
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false

--- a/site-modules/profile/lib/puppet/provider/example/example.rb
+++ b/site-modules/profile/lib/puppet/provider/example/example.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the example type using the Resource API.
+class Puppet::Provider::Example::Example < Puppet::ResourceApi::SimpleProvider
+  def get(context)
+    context.debug('Returning pre-canned example data')
+    [
+      {
+        name: 'foo',
+        ensure: 'present',
+      },
+      {
+        name: 'bar',
+        ensure: 'present',
+      },
+    ]
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+end

--- a/site-modules/profile/lib/puppet/type/example.rb
+++ b/site-modules/profile/lib/puppet/type/example.rb
@@ -5,7 +5,7 @@ require 'puppet/resource_api'
 Puppet::ResourceApi.register_type(
   name: 'example',
   docs: <<-EOS,
-@summary a example type
+@summary An example type
 @example
 example { 'foo':
   ensure => 'present',

--- a/site-modules/profile/lib/puppet/type/example.rb
+++ b/site-modules/profile/lib/puppet/type/example.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'example',
+  docs: <<-EOS,
+@summary a example type
+@example
+example { 'foo':
+  ensure => 'present',
+}
+
+This type provides Puppet with the capabilities to manage ...
+
+If your type uses autorequires, please document as shown below, else delete
+these lines.
+**Autorequires**:
+* `Package[foo]`
+EOS
+  features: [],
+  attributes: {
+    ensure: {
+      type: 'Enum[present, absent]',
+      desc: 'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name: {
+      type: 'String',
+      desc: 'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+  },
+)

--- a/site-modules/profile/spec/unit/puppet/provider/example/example_spec.rb
+++ b/site-modules/profile/spec/unit/puppet/provider/example/example_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::Example')
+require 'puppet/provider/example/example'
+
+RSpec.describe Puppet::Provider::Example::Example do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  describe '#get' do
+    it 'processes resources' do
+      expect(context).to receive(:debug).with('Returning pre-canned example data')
+      expect(provider.get(context)).to eq [
+        {
+          name: 'foo',
+          ensure: 'present',
+        },
+        {
+          name: 'bar',
+          ensure: 'present',
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      expect(context).to receive(:notice).with(%r{\ACreating 'a'})
+
+      provider.create(context, 'a', name: 'a', ensure: 'present')
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'foo'})
+
+      provider.update(context, 'foo', name: 'foo', ensure: 'present')
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      expect(context).to receive(:notice).with(%r{\ADeleting 'foo'})
+
+      provider.delete(context, 'foo')
+    end
+  end
+end

--- a/site-modules/profile/spec/unit/puppet/type/example_spec.rb
+++ b/site-modules/profile/spec/unit/puppet/type/example_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/example'
+
+RSpec.describe 'the example type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:example)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Example created using `pdk new provider example`

## Validation

```bash
$ pdk validate                     
pdk (INFO): Using Ruby 3.2.11
pdk (INFO): Using Puppet 8.18.0
pdk (INFO): Running all available validators...
...
┌ [✔] Running metadata validators ...
├── [✔] Checking metadata syntax (metadata.json tasks/*.json).
└── [✔] Checking module metadata style (metadata.json).
┌ [✔] Running puppet validators ...
├── [✔] Checking Puppet manifest syntax (**/*.pp).
└── [✔] Checking Puppet manifest style (**/*.pp).
┌ [✔] Running ruby validators ...
└── [✔] Checking Ruby code style (**/**.rb).
┌ [✔] Running tasks validators ...
├── [✔] Checking task names (tasks/**/*).
└── [✔] Checking task metadata style (tasks/*.json).
┌ [✔] Running yaml validators ...
└── [✔] Checking YAML syntax (**/*.yaml **/*.yml).
```
```bash
$ pdk test unit                    
pdk (INFO): Using Ruby 3.2.11
pdk (INFO): Using Puppet 8.18.0
[✔] Preparing to run the unit tests.
...
Coverage Report:

Total resources:   3
Touched resources: 2
Resource coverage: 66.67%

Untouched resources:
  Notify[This is the base profile. It should be included on all nodes.]


Finished in 11.26 seconds (files took 4.83 seconds to load)
240 examples, 0 failures
```